### PR TITLE
Make vert 4.2.0.CR1 compile to native image

### DIFF
--- a/steps/step-2/src/main/resources/META-INF/native-image/com.example/myapp/native-image.properties
+++ b/steps/step-2/src/main/resources/META-INF/native-image/com.example/myapp/native-image.properties
@@ -14,7 +14,7 @@ io.vertx,\
 com.fasterxml.jackson \
 --initialize-at-run-time=io.netty.channel.DefaultChannelId,\
 io.netty.buffer.PooledByteBufAllocator,\
-io.vertx.core.net.impl.PartialPooledByteBufAllocator,\
+io.vertx.core.buffer.impl.PartialPooledByteBufAllocator,\
 io.netty.util.NetUtil,\
 io.netty.channel.socket.InternetProtocolFamily,\
 io.netty.resolver.HostsFileEntriesResolver,\


### PR DESCRIPTION
I don't know since which version vert.x requires these changes but without them
ver.x 4.2.0.CR1 won't compile to native with GraalVM 21.1.0-21.3.0.