### PR TITLE
Update native-image plugin (GraalVM 21.3.0 + Vert.x 4.2.3)

### DIFF
--- a/steps/step-2/pom.xml
+++ b/steps/step-2/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 
@@ -10,6 +11,13 @@
   <name>hello_native</name>
 
   <properties>
+    <vertx.version>4.2.1</vertx.version>
+
+    <graal.plugin.version>0.9.8</graal.plugin.version>
+    <vertx.plugin.version>1.0.22</vertx.plugin.version>
+    <failsafe.plugin.version>2.22.2</failsafe.plugin.version>
+    <junit5.webclient.version>0.3.0</junit5.webclient.version>
+
     <vertx.verticle>vertx.APIClientVerticle</vertx.verticle>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -17,7 +25,6 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.testSource>1.8</maven.compiler.testSource>
     <maven.compiler.testTarget>1.8</maven.compiler.testTarget>
-    <graal.version>20.3.0</graal.version>
   </properties>
 
   <dependencyManagement>
@@ -25,7 +32,7 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>${vertx.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -41,6 +48,17 @@
       <groupId>io.vertx</groupId>
       <artifactId>vertx-web-client</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.reactiverse</groupId>
+      <artifactId>reactiverse-junit5-web-client</artifactId>
+      <version>${junit5.webclient.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -48,7 +66,7 @@
       <plugin>
         <groupId>io.reactiverse</groupId>
         <artifactId>vertx-maven-plugin</artifactId>
-        <version>1.0.22</version>
+        <version>${vertx.plugin.version}</version>
         <executions>
           <execution>
             <id>vmp</id>
@@ -62,13 +80,13 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.graalvm.nativeimage</groupId>
-        <artifactId>native-image-maven-plugin</artifactId>
-        <version>${graal.version}</version>
+        <groupId>org.graalvm.buildtools</groupId>
+        <artifactId>native-maven-plugin</artifactId>
+        <version>${graal.plugin.version}</version>
         <executions>
           <execution>
             <goals>
-              <goal>native-image</goal>
+              <goal>build</goal>
             </goals>
             <phase>package</phase>
           </execution>
@@ -78,6 +96,18 @@
           <mainClass>io.vertx.core.Launcher</mainClass>
           <buildArgs>-H:+PrintClassInitialization -H:+ReportExceptionStackTraces</buildArgs>
         </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>${failsafe.plugin.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/steps/step-2/pom.xml
+++ b/steps/step-2/pom.xml
@@ -11,7 +11,7 @@
   <name>hello_native</name>
 
   <properties>
-    <vertx.version>4.2.1</vertx.version>
+    <vertx.version>4.2.3</vertx.version>
 
     <graal.plugin.version>0.9.8</graal.plugin.version>
     <vertx.plugin.version>1.0.22</vertx.plugin.version>

--- a/steps/step-2/src/main/java/vertx/APIClientVerticle.java
+++ b/steps/step-2/src/main/java/vertx/APIClientVerticle.java
@@ -1,3 +1,4 @@
+
 package vertx;
 
 import io.vertx.core.AbstractVerticle;
@@ -8,21 +9,22 @@ import io.vertx.ext.web.client.WebClientOptions;
 
 public class APIClientVerticle extends AbstractVerticle {
 
-  @Override
-  public void start() {
-    WebClient client = WebClient.create(vertx, new WebClientOptions().setSsl(true).setTrustAll(true));
+    @Override
+    public void start() {
+        final WebClient client = WebClient.create(vertx, new WebClientOptions().setSsl(true).setTrustAll(true));
 
-    client
-      .get(443, "icanhazdadjoke.com", "/")
-      .putHeader("Accept", "text/plain")
-      .send(ar -> {
-        if (ar.succeeded()) {
-          HttpResponse<Buffer> response = ar.result();
-          System.out.println("Got HTTP response with status " + response.statusCode() + " with data "
-              + response.body().toString("ISO-8859-1"));
-        } else {
-          ar.cause().printStackTrace();
-        }
-    });
-  }
+        client.get(443, "icanhazdadjoke.com", "/").putHeader("Accept", "text/plain").send(ar -> {
+            if (ar.succeeded()) {
+                final HttpResponse<Buffer> response = ar.result();
+
+                System.out.println("Got HTTP response with status " + response.statusCode() + " with data " +
+                        response.body().toString("ISO-8859-1"));
+            } else {
+                ar.cause().printStackTrace();
+            }
+
+            // Submit our API request and then exit (to make testing easier)
+            getVertx().close();
+        });
+    }
 }

--- a/steps/step-2/src/main/java/vertx/APIClientVerticle.java
+++ b/steps/step-2/src/main/java/vertx/APIClientVerticle.java
@@ -1,4 +1,3 @@
-
 package vertx;
 
 import io.vertx.core.AbstractVerticle;
@@ -9,22 +8,24 @@ import io.vertx.ext.web.client.WebClientOptions;
 
 public class APIClientVerticle extends AbstractVerticle {
 
-    @Override
-    public void start() {
-        final WebClient client = WebClient.create(vertx, new WebClientOptions().setSsl(true).setTrustAll(true));
+  @Override
+  public void start() {
+    WebClient client = WebClient.create(vertx, new WebClientOptions().setSsl(true).setTrustAll(true));
 
-        client.get(443, "icanhazdadjoke.com", "/").putHeader("Accept", "text/plain").send(ar -> {
-            if (ar.succeeded()) {
-                final HttpResponse<Buffer> response = ar.result();
+    client
+      .get(443, "icanhazdadjoke.com", "/")
+      .putHeader("Accept", "text/plain")
+      .send(ar -> {
+        if (ar.succeeded()) {
+          HttpResponse<Buffer> response = ar.result();
+          System.out.println("Got HTTP response with status " + response.statusCode() + " with data "
+              + response.body().toString("ISO-8859-1"));
+        } else {
+          ar.cause().printStackTrace();
+        }
 
-                System.out.println("Got HTTP response with status " + response.statusCode() + " with data " +
-                        response.body().toString("ISO-8859-1"));
-            } else {
-                ar.cause().printStackTrace();
-            }
-
-            // Submit our API request and then exit (to make testing easier)
-            getVertx().close();
-        });
-    }
+        // Submit our API request and then exit (to make testing easier)
+        getVertx().close();
+    });
+  }
 }

--- a/steps/step-2/src/main/resources/META-INF/native-image/com.example/myapp/native-image.properties
+++ b/steps/step-2/src/main/resources/META-INF/native-image/com.example/myapp/native-image.properties
@@ -15,9 +15,16 @@ io.netty,\
 io.vertx,\
 com.fasterxml.jackson \
 --initialize-at-run-time=\
+io.netty.internal.tcnative.SSL,\
+io.netty.internal.tcnative.SSLPrivateKeyMethod,\
+io.netty.internal.tcnative.AsyncSSLPrivateKeyMethod,\
+io.netty.internal.tcnative.CertificateVerifier,\
 io.netty.channel.DefaultChannelId,\
+io.netty.handler.codec.compression.BrotliOptions,\
 io.netty.handler.codec.compression.BrotliDecoder$1,\
 io.netty.util.internal.logging.Slf4JLoggerFactory,\
+io.netty.handler.ssl.OpenSslPrivateKeyMethod,\
+io.netty.handler.ssl.OpenSslAsyncPrivateKeyMethod,\
 io.netty.handler.ssl.OpenSslSessionContext,\
 io.netty.handler.ssl.BouncyCastleAlpnSslUtils,\
 io.netty.buffer.PooledByteBufAllocator,\

--- a/steps/step-2/src/main/resources/META-INF/native-image/com.example/myapp/native-image.properties
+++ b/steps/step-2/src/main/resources/META-INF/native-image/com.example/myapp/native-image.properties
@@ -1,4 +1,5 @@
-Args = --enable-http \
+Args =\
+--enable-http \
 --enable-https \
 --allow-incomplete-classpath \
 --enable-all-security-services \
@@ -7,16 +8,21 @@ Args = --enable-http \
 -H:ReflectionConfigurationResources=${.}/reflect-config.json \
 -H:JNIConfigurationResources=${.}/jni-config.json \
 -H:ResourceConfigurationResources=${.}/resource-config.json \
---initialize-at-build-time=org.slf4j.LoggerFactory,\
+--initialize-at-build-time=\
+org.slf4j.LoggerFactory,\
 org.slf4j.impl.StaticLoggerBinder$,\
 io.netty,\
 io.vertx,\
 com.fasterxml.jackson \
---initialize-at-run-time=io.netty.channel.DefaultChannelId,\
+--initialize-at-run-time=\
+io.netty.channel.DefaultChannelId,\
+io.netty.handler.codec.compression.BrotliDecoder$1,\
+io.netty.util.internal.logging.Slf4JLoggerFactory,\
+io.netty.handler.ssl.OpenSslSessionContext,\
+io.netty.handler.ssl.BouncyCastleAlpnSslUtils,\
 io.netty.buffer.PooledByteBufAllocator,\
 io.vertx.core.buffer.impl.PartialPooledByteBufAllocator,\
 io.netty.util.NetUtil,\
-io.netty.channel.socket.InternetProtocolFamily,\
 io.netty.resolver.HostsFileEntriesResolver,\
 io.netty.resolver.dns.DnsNameResolver,\
 io.netty.resolver.dns.DnsServerAddressStreamProviders,\

--- a/steps/step-2/src/test/java/vertx/HowtoVerticlesIT.java
+++ b/steps/step-2/src/test/java/vertx/HowtoVerticlesIT.java
@@ -1,0 +1,135 @@
+
+package vertx;
+
+import static io.reactiverse.junit5.web.TestRequest.bodyResponse;
+import static io.reactiverse.junit5.web.TestRequest.statusCode;
+import static io.reactiverse.junit5.web.TestRequest.testRequest;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.reactiverse.junit5.web.WebClientOptionsInject;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.WebClientOptions;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+
+/**
+ * Tests of the native images created by this project.
+ */
+@ExtendWith(VertxExtension.class)
+class HowtoVerticlesIT {
+
+    /**
+     * Expected log output.
+     */
+    private static final String EXPECTED_OUTPUT = "Server listening";
+
+    /**
+     * WebClient options for tests.
+     */
+    @WebClientOptionsInject
+    public WebClientOptions options = new WebClientOptions().setDefaultHost("localhost").setTrustAll(true);
+
+    /**
+     * Tests the HTTPVerticle class.
+     *
+     * @param vertx A Vert.x instance
+     * @param testContext A test context
+     * @throws IOException If there is trouble reading from the test's process
+     */
+    @Test
+    final void testHTTPVerticle(final Vertx vertx, final VertxTestContext testContext, final WebClient client)
+            throws IOException {
+        final Process process = getProcess("vertx.HTTPVerticle");
+
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+            testContext.verify(() -> {
+                // Check that server started
+                assertEquals(EXPECTED_OUTPUT, reader.readLine().substring(0, EXPECTED_OUTPUT.length()));
+                // Check that it responds as expected
+                testRequest(client, HttpMethod.GET, "/").with(request -> request.port(8080))
+                        .expect(statusCode(200), bodyResponse(Buffer.buffer("Hello from Vert.x!"), "text/plain"))
+                        .send(testContext, (VertxTestContext.ExecutionBlock) () -> {
+                            process.destroyForcibly();
+                            testContext.completeNow();
+                        });
+            });
+        }
+    }
+
+    /**
+     * Tests the HTTPSVerticle class.
+     *
+     * @param vertx A Vert.x instance
+     * @param testContext A test context
+     * @throws IOException If there is trouble reading from the test's process
+     */
+    @Test
+    final void testHTTPSVerticle(final Vertx vertx, final VertxTestContext testContext, final WebClient client)
+            throws IOException {
+        final Process process = getProcess("vertx.HTTPSVerticle");
+
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+            testContext.verify(() -> {
+                // Check that server started
+                assertEquals(EXPECTED_OUTPUT, reader.readLine().substring(0, EXPECTED_OUTPUT.length()));
+                // Check that it responds as expected
+                testRequest(client, HttpMethod.GET, "/").with(request -> request.port(8443).ssl(true))
+                        .expect(statusCode(200), bodyResponse(Buffer.buffer("Hello from Vert.x!"), "text/plain"))
+                        .send(testContext, (VertxTestContext.ExecutionBlock) () -> {
+                            process.destroyForcibly();
+                            testContext.completeNow();
+                        });
+            });
+        }
+    }
+
+    /**
+     * Tests the output from APIClientVerticle.
+     *
+     * @param vertx A Vert.x instance
+     * @param testContext A test context
+     * @throws IOException If there is trouble reading from the test's process
+     */
+    @Test
+    final void testAPIClientVerticle(final Vertx vertx, final VertxTestContext testContext) throws IOException {
+        final Process process = getProcess("vertx.APIClientVerticle");
+
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+            final StringBuilder sb = new StringBuilder();
+
+            String line;
+
+            while ((line = reader.readLine()) != null) {
+                sb.append(line).append(' ');
+            }
+
+            testContext.verify(() -> {
+                process.destroyForcibly();
+                assertTrue(sb.toString().contains("Got HTTP response with status 200"));
+                testContext.completeNow();
+            });
+        }
+    }
+
+    /**
+     * Gets a process for a particular test.
+     *
+     * @param test The test being run
+     * @return A process
+     * @throws IOException If there is trouble reading from the process
+     */
+    final private Process getProcess(final String test) throws IOException {
+        return new ProcessBuilder("target/hello_native", "run", test).redirectErrorStream(true).start();
+    }
+}


### PR DESCRIPTION
* Update the step 2 POM to use Vert.x 4.2.1 and GraalVM 21.3.0
* Update the GraalVM native-image plugin to use the new/latest version
* Move dependency and plugin versions into the POM's properties section
* Add tests of the three verticles

I can remove the tests if there isn't a desire for them. I'd also be glad to work on a GitHub Action for running the tests on PRs if this is desired.